### PR TITLE
Mods picker

### DIFF
--- a/Fronter.NET.sln.DotSettings
+++ b/Fronter.NET.sln.DotSettings
@@ -3,5 +3,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Avalonia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fronter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Imperator/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MODSDISABLED/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Outputtable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Patreon/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Fronter.NET.sln.DotSettings
+++ b/Fronter.NET.sln.DotSettings
@@ -4,5 +4,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fronter/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Imperator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=MODSDISABLED/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MODSFOUND/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=MODSNOTFOUND/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Outputtable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Patreon/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -62,11 +62,4 @@
     <ItemGroup>
       <UpToDateCheckInput Remove="Styles\MdStyle.axaml" />
     </ItemGroup>
-
-    <ItemGroup>
-      <Compile Update="Views\ModsPickerView.axaml.cs">
-        <DependentUpon>ModsPickerView.axaml</DependentUpon>
-        <SubType>Code</SubType>
-      </Compile>
-    </ItemGroup>
 </Project>

--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -62,4 +62,11 @@
     <ItemGroup>
       <UpToDateCheckInput Remove="Styles\MdStyle.axaml" />
     </ItemGroup>
+
+    <ItemGroup>
+      <Compile Update="Views\ModsPickerView.axaml.cs">
+        <DependentUpon>ModsPickerView.axaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+    </ItemGroup>
 </Project>

--- a/Fronter.NET/Models/Configuration/Configuration.cs
+++ b/Fronter.NET/Models/Configuration/Configuration.cs
@@ -19,7 +19,6 @@ public class Configuration {
 	public string TargetGame { get; private set; } = string.Empty;
 	public string? ModAutoGenerationSource { get; private set; } = null;
 	public List<Mod> AutoLocatedMods { get; } = new();
-	// public HashSet<string> PreloadedModFileNames { get; } = new(); // TODO: REMOVE
 	public bool CopyToTargetGameModDirectory { get; set; } = true;
 	public bool UpdateCheckerEnabled { get; private set; } = false;
 	public bool CheckForUpdatesOnStartup { get; private set; } = false;

--- a/Fronter.NET/Models/Configuration/Mod.cs
+++ b/Fronter.NET/Models/Configuration/Mod.cs
@@ -14,4 +14,5 @@ public class Mod : ViewModelBase {
 	}
 	public string Name { get; private set; } = string.Empty;
 	public string FileName { get; private set; }
+	public bool Enabled { get; set; } = false;
 }

--- a/Fronter.NET/Models/Configuration/Mod.cs
+++ b/Fronter.NET/Models/Configuration/Mod.cs
@@ -7,7 +7,7 @@ public class Mod : ViewModelBase {
 	public Mod(string modPath) {
 		var parser = new Parser();
 		parser.RegisterKeyword("name", reader => Name = reader.GetString());
-		parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreItem);
+		parser.IgnoreUnregisteredItems();
 
 		parser.ParseFile(modPath);
 		FileName = CommonFunctions.TrimPath(modPath);

--- a/Fronter.NET/Models/Configuration/RequiredFolder.cs
+++ b/Fronter.NET/Models/Configuration/RequiredFolder.cs
@@ -8,7 +8,9 @@ namespace Fronter.Models.Configuration;
 
 public class RequiredFolder : RequiredPath {
 	private static readonly ILog logger = LogManager.GetLogger("Required folder");
-	public RequiredFolder(BufferedReader reader) {
+	public RequiredFolder(BufferedReader reader, Configuration configuration) {
+		config = configuration;
+		
 		var parser = new Parser();
 		RegisterKeys(parser);
 		parser.ParseStream(reader);
@@ -23,7 +25,7 @@ public class RequiredFolder : RequiredPath {
 		parser.RegisterKeyword("searchPathType", reader => SearchPathType = reader.GetString());
 		parser.RegisterKeyword("searchPathID", reader => SearchPathId = reader.GetString());
 		parser.RegisterKeyword("searchPath", reader => SearchPath = reader.GetString());
-		parser.RegisterRegex(CommonRegexes.Catchall, ParserHelpers.IgnoreAndLogItem);
+		parser.IgnoreAndLogUnregisteredItems();
 	}
 
 	// If we have folders listed, they are generally required. Override with false in conf file.
@@ -40,6 +42,12 @@ public class RequiredFolder : RequiredPath {
 
 			base.Value = value;
 			logger.Info($"{TranslationSource.Instance[DisplayName]} set to: {value}");
+			
+			if (Name == config.ModAutoGenerationSource) {
+				config.AutoLocateMods();
+			}
 		}
 	}
+
+	private readonly Configuration config;
 }

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -34,6 +34,7 @@ public class MainWindowViewModel : ViewModelBase {
 	public Configuration Config { get; }
 
 	public PathPickerViewModel PathPicker { get; }
+	public ModsPickerViewModel ModsPicker { get; }
 	public OptionsViewModel Options { get; }
 	public bool OptionsTabVisible => Options.Items.Any();
 

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -35,6 +35,7 @@ public class MainWindowViewModel : ViewModelBase {
 
 	public PathPickerViewModel PathPicker { get; }
 	public ModsPickerViewModel ModsPicker { get; }
+	public bool ModsPickerTabVisible => Config.ModAutoGenerationSource is not null;
 	public OptionsViewModel Options { get; }
 	public bool OptionsTabVisible => Options.Items.Any();
 
@@ -78,6 +79,7 @@ public class MainWindowViewModel : ViewModelBase {
 		LogGridAppender.LogGrid = logGrid;
 
 		PathPicker = new PathPickerViewModel(Config);
+		ModsPicker = new ModsPickerViewModel(Config);
 		Options = new OptionsViewModel(Config.Options);
 	}
 

--- a/Fronter.NET/ViewModels/ModsPickerViewModel.cs
+++ b/Fronter.NET/ViewModels/ModsPickerViewModel.cs
@@ -13,14 +13,21 @@ namespace Fronter.ViewModels;
 /// </summary>
 public class ModsPickerViewModel : ViewModelBase {
 	public ModsPickerViewModel(Configuration config) {
+		Mods = new ObservableCollection<Mod>(config.AutoLocatedMods);
+		
 		if (config.ModAutoGenerationSource is null) {
 			TabText = "MODSDISABLED";
 			return;
 		}
-		if (config.auto)
+
+		if (Mods.Count == 0) {
+			TabText = "MODSNOTFOUND";
+			return;
+		}
+
+		TabText = "MODSFOUND";
 	}
 
-	public ObservableCollection<RequiredFolder> RequiredFolders { get; }
-	public ObservableCollection<RequiredFile> RequiredFiles { get; }
+	public ObservableCollection<Mod> Mods { get; }
 	public string? TabText { get; private set; } = null;
 }

--- a/Fronter.NET/ViewModels/ModsPickerViewModel.cs
+++ b/Fronter.NET/ViewModels/ModsPickerViewModel.cs
@@ -1,0 +1,26 @@
+﻿using Avalonia.Controls;
+using commonItems;
+using Fronter.Extensions;
+using Fronter.Models.Configuration;
+using Fronter.Views;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Fronter.ViewModels;
+
+/// <summary>
+///     The ModsPickerViewModel lets the user select paths to various stuff the converter needs to know where to find.
+/// </summary>
+public class ModsPickerViewModel : ViewModelBase {
+	public ModsPickerViewModel(Configuration config) {
+		if (config.ModAutoGenerationSource is null) {
+			TabText = "MODSDISABLED";
+			return;
+		}
+		if (config.auto)
+	}
+
+	public ObservableCollection<RequiredFolder> RequiredFolders { get; }
+	public ObservableCollection<RequiredFile> RequiredFiles { get; }
+	public string? TabText { get; private set; } = null;
+}

--- a/Fronter.NET/Views/MainWindow.axaml
+++ b/Fronter.NET/Views/MainWindow.axaml
@@ -69,7 +69,7 @@
                     </ScrollViewer>
                 </TabItem>
                 
-                <TabItem Header="{ns:Loc MODSSTAB}" VerticalContentAlignment="Center">
+                <TabItem Header="{ns:Loc MODSTAB}" VerticalContentAlignment="Center" IsVisible="{Binding ModsPickerTabVisible}">
                     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
                         <views:ModsPickerView DataContext="{Binding ModsPicker}"/>
                     </ScrollViewer>

--- a/Fronter.NET/Views/MainWindow.axaml
+++ b/Fronter.NET/Views/MainWindow.axaml
@@ -69,6 +69,12 @@
                     </ScrollViewer>
                 </TabItem>
                 
+                <TabItem Header="{ns:Loc MODSSTAB}" VerticalContentAlignment="Center">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <views:ModsPickerView DataContext="{Binding ModsPicker}"/>
+                    </ScrollViewer>
+                </TabItem>
+                
                 <TabItem Header="{ns:Loc OPTIONSTAB}" VerticalContentAlignment="Center" IsVisible="{Binding OptionsTabVisible}">
                     <ScrollViewer VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto">
                         <views:OptionsView DataContext="{Binding Options}" />

--- a/Fronter.NET/Views/ModsPickerView.axaml
+++ b/Fronter.NET/Views/ModsPickerView.axaml
@@ -1,0 +1,58 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:viewModels="clr-namespace:Fronter.ViewModels"
+             xmlns:ns="clr-namespace:Fronter.Extensions"
+             x:Class="Fronter.Views.ModsPickerView"
+             x:DataType="viewModels:ModsPickerViewModel"
+             mc:Ignorable="d"
+             d:DesignHeight="300" d:DesignWidth="300">
+
+    <Design.DataContext>
+        <viewModels:ModsPickerViewModel />
+    </Design.DataContext>
+    
+    <UserControl.Styles>
+        <Style Selector="TextBlock.PathTextBlockStyle">
+            <Setter Property="Width" Value="250" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Padding" Value="3,5, 0, 0" />
+            <Setter Property="Margin" Value="6,2, 0, 5" />
+            <Setter Property="TextWrapping" Value="Wrap" />
+        </Style>
+        
+        <Style Selector="TextBox.PathTextBoxStyle">
+            <Setter Property="Margin" Value="6,2,0,5" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+        </Style>
+
+        <Style Selector="Button.PathBrowseButtonStyle">
+            <Setter Property="Height" Value="30"/>
+            <Setter Property="Width" Value="80" />
+            <Setter Property="VerticalAlignment" Value="Top" />
+            <Setter Property="Margin" Value="6, 2, 6, 5" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto,*">
+        <TextBlock Grid.Column="0" Grid.Row="0" Text="{ns:DynamicLoc TabText}"></TextBlock>
+        
+        <ScrollViewer Grid.Column="0" Grid.Row="1" >
+            <StackPanel>
+                <ItemsControl Items="{Binding Mods}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox
+                                Content="{Binding Name}"
+                                ToolTip.Tip="{Binding FileName}"
+                                IsChecked="{Binding Enabled, Mode=TwoWay}"
+                            />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/Fronter.NET/Views/ModsPickerView.axaml.cs
+++ b/Fronter.NET/Views/ModsPickerView.axaml.cs
@@ -1,0 +1,14 @@
+﻿using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Fronter.Views; 
+
+public partial class ModsPickerView : UserControl {
+	public ModsPickerView() {
+		InitializeComponent();
+	}
+
+	private void InitializeComponent() {
+		AvaloniaXamlLoader.Load(this);
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29546927/187797207-69a269f5-b5c8-4920-8b22-79bce31f7051.png)

Result in exported configuration.txt:
```
selectedMods = {
	"640.3.30___Aestuia.mod"
	"autosave.mod"
	"Dacia.mod"
	"test_save.mod"
}
```

The tab is only visible when `ModAutoGenerationSource` is not null. So just don't specify `autoGenerateModsFrom` in `fronter-configuration.txt` if you don't want to use it.