### PR TITLE
Preserve original timestamps from backends

### DIFF
--- a/Fronter.NET.Tests/Fronter.Tests.csproj
+++ b/Fronter.NET.Tests/Fronter.Tests.csproj
@@ -1,10 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fronter.NET/Extensions/LogExtensions.cs
+++ b/Fronter.NET/Extensions/LogExtensions.cs
@@ -7,7 +7,9 @@ namespace Fronter.Extensions;
 public static class LogExtensions {
 	public static void LogWithCustomTimestamp(this ILog log, DateTime timestamp, Level level, string message) {
 		var loggingEventDate = new LoggingEventData {
+#pragma warning disable CS0618
 			TimeStamp = timestamp, Level = level, Message = message
+#pragma warning restore CS0618
 		};
 		var loggingEvent = new LoggingEvent(loggingEventDate);
 		log.Logger.Log(loggingEvent);

--- a/Fronter.NET/Extensions/LogExtensions.cs
+++ b/Fronter.NET/Extensions/LogExtensions.cs
@@ -1,0 +1,15 @@
+﻿using log4net;
+using log4net.Core;
+using System;
+
+namespace Fronter.Extensions; 
+
+public static class LogExtensions {
+	public static void LogWithCustomTimestamp(this ILog log, DateTime timestamp, Level level, string message) {
+		var loggingEventDate = new LoggingEventData {
+			TimeStamp = timestamp, Level = level, Message = message
+		};
+		var loggingEvent = new LoggingEvent(loggingEventDate);
+		log.Logger.Log(loggingEvent);
+	}
+}

--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
         <Nullable>enable</Nullable>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <AssemblyName>ConverterFrontend</AssemblyName>
 
         <IsPackable>false</IsPackable>
+
+        <LangVersion>11</LangVersion>
 
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -33,7 +33,7 @@ public class LogGridAppender : MemoryAppender {
 	protected override void Append(LoggingEvent loggingEvent) {
 		var newLogLine = new LogLine {
 			Level = loggingEvent.Level,
-			// tab characters are incorrectly displayed in the log grid as of Avalonia 0.10.13
+			// Tab characters are incorrectly displayed in the log grid as of Avalonia 0.10.18.
 			Message = loggingEvent.RenderedMessage.Replace("\t", "    "),
 			Timestamp = GetTimestampString(loggingEvent.TimeStamp)
 		};

--- a/Fronter.NET/Services/ConverterLauncher.cs
+++ b/Fronter.NET/Services/ConverterLauncher.cs
@@ -1,4 +1,5 @@
 ﻿using commonItems;
+using Fronter.Extensions;
 using Fronter.Models.Configuration;
 using log4net;
 using log4net.Core;
@@ -48,7 +49,20 @@ internal class ConverterLauncher {
 			if (level is null && string.IsNullOrEmpty(logLine.Message)) {
 				return;
 			}
-			logger.Log(level ?? lastLevelFromBackend ?? Level.Info, logLine.Message);
+
+			// Get timestamp datetime.
+			DateTime timestamp;
+			if (string.IsNullOrWhiteSpace(logLine.Timestamp)) {
+				timestamp = DateTime.Now;
+			} else {
+				timestamp = Convert.ToDateTime(logLine.Timestamp);
+			}
+			
+			// Get level to display.
+			var logLevel = level ?? lastLevelFromBackend ?? Level.Info;
+
+			logger.LogWithCustomTimestamp(timestamp, logLevel, logLine.Message);
+			
 			if (level is not null) {
 				lastLevelFromBackend = level;
 			}


### PR DESCRIPTION
Basically, previously when frontend received a log line from the backend, it just logged it back to its own log (which is written to log.txt and the visual log grid). This is simple, but changes the timestamp.
All I had to do was create a `LogWithCustomTimestamp` extension method to preserve the original one.