### PR TITLE
Indeterminate progress bar during mod copying

### DIFF
--- a/Fronter.NET/Models/Configuration/Configuration.cs
+++ b/Fronter.NET/Models/Configuration/Configuration.cs
@@ -21,6 +21,7 @@ public class Configuration {
 	public string? ModAutoGenerationSource { get; private set; } = null;
 	public ObservableCollection<Mod> AutoLocatedMods { get; } = new();
 	public bool CopyToTargetGameModDirectory { get; set; } = true;
+	public ushort ProgressOnCopyingComplete { get; set; } = 109; 
 	public bool OverwritePlayset { get; set; } = false;
 	public bool UpdateCheckerEnabled { get; private set; } = false;
 	public bool CheckForUpdatesOnStartup { get; private set; } = false;
@@ -102,6 +103,9 @@ public class Configuration {
 		});
 		parser.RegisterKeyword("copyToTargetGameModDirectory", reader => {
 			CopyToTargetGameModDirectory = reader.GetString() == "true";
+		});
+		parser.RegisterKeyword("progressOnCopyingComplete", reader => {
+			ProgressOnCopyingComplete = (ushort)reader.GetInt();
 		});
 		parser.RegisterKeyword("overwritePlayset", reader => {
 			OverwritePlayset = reader.GetString() == "true";

--- a/Fronter.NET/Services/ConverterLauncher.cs
+++ b/Fronter.NET/Services/ConverterLauncher.cs
@@ -40,7 +40,9 @@ internal class ConverterLauncher {
 			WorkingDirectory = CommonFunctions.GetPath(backendExePathRelativeToFrontend),
 			CreateNoWindow = true,
 			UseShellExecute = false,
-			RedirectStandardOutput = true
+			RedirectStandardOutput = true,
+			RedirectStandardError = true,
+			RedirectStandardInput = true,
 		};
 		using Process process = new() { StartInfo = startInfo };
 		process.OutputDataReceived += (sender, args) => {

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -97,6 +97,12 @@ public class MainWindowViewModel : ViewModelBase {
 		set => this.RaiseAndSetIfChanged(ref progress, value);
 	}
 
+	private bool indeterminateProgress = false;
+	public bool IndeterminateProgress {
+		get => indeterminateProgress;
+		set => this.RaiseAndSetIfChanged(ref indeterminateProgress, value);
+	}
+
 	private bool VerifyMandatoryPaths() {
 		foreach (var folder in Config.RequiredFolders) {
 			if (!folder.Mandatory || Directory.Exists(folder.Value)) {
@@ -145,9 +151,11 @@ public class MainWindowViewModel : ViewModelBase {
 					var modCopier = new ModCopier(Config);
 					bool copySuccess;
 					var copyThread = new Thread(() => {
+						IndeterminateProgress = true;
 						CopyStatus = "CONVERTSTATUSIN";
 						copySuccess = modCopier.CopyMod();
 						CopyStatus = copySuccess ? "CONVERTSTATUSPOSTSUCCESS" : "CONVERTSTATUSPOSTFAIL";
+						IndeterminateProgress = false;
 					});
 					copyThread.Start();
 				}

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -154,6 +154,7 @@ public class MainWindowViewModel : ViewModelBase {
 					var copyThread = new Thread(() => {
 						IndeterminateProgress = true;
 						CopyStatus = "CONVERTSTATUSIN";
+						
 						copySuccess = modCopier.CopyMod();
 						CopyStatus = copySuccess ? "CONVERTSTATUSPOSTSUCCESS" : "CONVERTSTATUSPOSTFAIL";
 						Progress = Config.ProgressOnCopyingComplete;

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -155,6 +155,7 @@ public class MainWindowViewModel : ViewModelBase {
 						CopyStatus = "CONVERTSTATUSIN";
 						copySuccess = modCopier.CopyMod();
 						CopyStatus = copySuccess ? "CONVERTSTATUSPOSTSUCCESS" : "CONVERTSTATUSPOSTFAIL";
+						Progress = 109;
 						IndeterminateProgress = false;
 					});
 					copyThread.Start();

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
+using commonItems;
 using Fronter.Extensions;
 using Fronter.LogAppenders;
 using Fronter.Models;
@@ -155,7 +156,7 @@ public class MainWindowViewModel : ViewModelBase {
 						CopyStatus = "CONVERTSTATUSIN";
 						copySuccess = modCopier.CopyMod();
 						CopyStatus = copySuccess ? "CONVERTSTATUSPOSTSUCCESS" : "CONVERTSTATUSPOSTFAIL";
-						Progress = 109;
+						Progress = Config.ProgressOnCopyingComplete;
 						IndeterminateProgress = false;
 					});
 					copyThread.Start();

--- a/Fronter.NET/Views/MainWindow.axaml
+++ b/Fronter.NET/Views/MainWindow.axaml
@@ -127,7 +127,7 @@
                                 <TextBlock Grid.Row="2" Grid.Column="0" Text="{ns:Loc CONVERTCOPYING}"></TextBlock>
                                 <TextBlock Grid.Row="2" Grid.Column="1" Text="{ns:DynamicLoc CopyStatus}"></TextBlock>
                             </Grid>
-                            <ProgressBar Margin="4" Height="20" Value="{Binding Progress}" BorderThickness="1" BorderBrush="Gray"/>
+                            <ProgressBar Margin="4" Height="20" Value="{Binding Progress}" BorderThickness="1" BorderBrush="Gray" IsIndeterminate="{Binding IndeterminateProgress}"/>
                             <TextBlock Text="{Binding Progress, StringFormat={}{0}%}" HorizontalAlignment="Center"></TextBlock>
                             <Button Margin="4,15,4,4" HorizontalAlignment="Center" Name="ConvertButton" Command="{Binding LaunchConverter}" IsEnabled="{Binding ConvertButtonEnabled}" Content="{ns:Loc CONVERTBUTTON}"/>
                         </StackPanel>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ displayName = DISPLAYNAME
 sourceGame = SOURCEGAME
 targetGame = TARGETGAME
 copyToTargetGameModDirectory = true
+progressOnCopyingComplete = 109 # Final progressbar value after completion of mod copying.
 
 requiredFile = {
 	name = SaveGame


### PR DESCRIPTION
Video:
https://discord.com/channels/612683871112396800/703339837713023007/1043590041101926450

Now ends with 109% by default.
![obraz](https://user-images.githubusercontent.com/29546927/202873048-d7c52411-7d94-424b-8ac6-52d8cebd3573.png)

The final progress value can be configured:
```
progressOnCopyingComplete = 109 # Final progressbar value after completion of mod copying.
```