### PR TITLE
Use .NET 7

### DIFF
--- a/Fronter.NET.Tests/Fronter.Tests.csproj
+++ b/Fronter.NET.Tests/Fronter.Tests.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <RuntimeIdentifiers>win-x64;osx-x64;linux-x64</RuntimeIdentifiers>
         <Nullable>enable</Nullable>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -9,7 +9,7 @@
 
         <IsPackable>false</IsPackable>
 
-        <LangVersion>10</LangVersion>
+        <LangVersion>11</LangVersion>
 
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/Fronter.NET/Properties/PublishProfiles/linux-x64.pubxml
+++ b/Fronter.NET/Properties/PublishProfiles/linux-x64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>Release</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Fronter.NET/Properties/PublishProfiles/osx-x64.pubxml
+++ b/Fronter.NET/Properties/PublishProfiles/osx-x64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>Release</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifier>osx-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>

--- a/Fronter.NET/Properties/PublishProfiles/win-x64.pubxml
+++ b/Fronter.NET/Properties/PublishProfiles/win-x64.pubxml
@@ -8,7 +8,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <Platform>Any CPU</Platform>
     <PublishDir>Release</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishSingleFile>true</PublishSingleFile>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.405",
+    "version": "7.0.102",
     "rollForward": "disable"
   }
 }


### PR DESCRIPTION
Now that we've determined the cause of the frontend not working on Windows 7, .NET 7 can be used again.