### PR TITLE
Downgrade Avalonia to 11.1.5

### DIFF
--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -11,7 +11,7 @@
         <IsPackable>false</IsPackable>
         
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
-        <AvaloniaVersion>11.2.1</AvaloniaVersion>
+        <AvaloniaVersion>11.1.5</AvaloniaVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
         <ApplicationManifest>app.manifest</ApplicationManifest>


### PR DESCRIPTION
On Avalonia 11.2.1, opening the update notification MessageBox results in the following exception:

> System.NotSupportedException: Unsupported IBinding implementation 'Markdown.Avalonia.Extensions.StaticBinding'.
>    at Avalonia.Data.Core.MultiBindingExpression.StartCore()
>    at Avalonia.Data.Core.UntypedBindingExpressionBase.Start(Boolean produceValue)
>    at Avalonia.Data.Core.UntypedBindingExpressionBase.Avalonia.PropertyStore.IValueEntry.HasValue()
>    at Avalonia.PropertyStore.ValueStore.ReevaluateEffectiveValues(IValueEntry changedValueEntry)
>    at Avalonia.PropertyStore.ValueStore.EndStyling()
>    at Avalonia.StyledElement.ApplyStyling()
>    at Avalonia.StyledElement.ApplyStyling()
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.OnAttachedToLogicalTreeCore(LogicalTreeAttachmentEventArgs e)
>    at Avalonia.StyledElement.Avalonia.Controls.ISetLogicalParent.SetParent(ILogical parent)
>    at Avalonia.Controls.Primitives.TemplatedControl.ApplyTemplate()
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Controls.Grid.MeasureCell(Int32 cell, Boolean forceInfinityV)
>    at Avalonia.Controls.Grid.MeasureCellsGroup(Int32 cellsHead, Size referenceSize, Boolean ignoreDesiredSizeU, Boolean forceInfinityV, Boolean& hasDesiredSizeUChanged)
>    at Avalonia.Controls.Grid.MeasureCellsGroup(Int32 cellsHead, Size referenceSize, Boolean ignoreDesiredSizeU, Boolean forceInfinityV)
>    at Avalonia.Controls.Grid.MeasureOverride(Size constraint)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Controls.Grid.MeasureCell(Int32 cell, Boolean forceInfinityV)
>    at Avalonia.Controls.Grid.MeasureCellsGroup(Int32 cellsHead, Size referenceSize, Boolean ignoreDesiredSizeU, Boolean forceInfinityV, Boolean& hasDesiredSizeUChanged)
>    at Avalonia.Controls.Grid.MeasureCellsGroup(Int32 cellsHead, Size referenceSize, Boolean ignoreDesiredSizeU, Boolean forceInfinityV)
>    at Avalonia.Controls.Grid.MeasureOverride(Size constraint)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.LayoutHelper.MeasureChild(Layoutable control, Size availableSize, Thickness padding, Thickness borderThickness)
>    at Avalonia.Controls.Presenters.ContentPresenter.MeasureOverride(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureOverride(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.LayoutHelper.MeasureChild(Layoutable control, Size availableSize, Thickness padding, Thickness borderThickness)
>    at Avalonia.Controls.Presenters.ContentPresenter.MeasureOverride(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.LayoutHelper.MeasureChild(Layoutable control, Size availableSize, Thickness padding)
>    at Avalonia.Controls.Decorator.MeasureOverride(Size availableSize)
>    at Avalonia.Controls.Primitives.VisualLayerManager.MeasureOverride(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureOverride(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.Layoutable.MeasureOverride(Size availableSize)
>    at Avalonia.Controls.Window.MeasureOverride(Size availableSize)
>    at Avalonia.Controls.WindowBase.MeasureCore(Size availableSize)
>    at Avalonia.Layout.Layoutable.Measure(Size availableSize)
>    at Avalonia.Layout.LayoutManager.Measure(Layoutable control)
>    at Avalonia.Layout.LayoutManager.ExecuteInitialLayoutPass()
>    at Avalonia.Controls.Window.ShowDialog[TResult](Window owner)
>    at Avalonia.Controls.Window.ShowDialog(Window owner)
>    at MsBox.Avalonia.MsBox`3.ShowWindowDialogAsync(Window owner)