### PR TITLE
Downgrade AWSSDK.S3 to a version that works correctly with Backblaze B2

### DIFF
--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -64,7 +64,7 @@
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
-        <PackageReference Include="AWSSDK.S3" Version="3.7.416.16" />
+        <PackageReference Include="AWSSDK.S3" Version="[3.7.411.7]" /> <!-- versions >= 3.7.412.0 didn't work correctly with Backblaze B2 as of 2025-05-17: https://www.backblaze.com/docs/en/cloud-storage-use-the-aws-sdk-for-net-with-backblaze-b2?highlight=Data%20Integrity%20Protection%20Headers -->
         <PackageReference Include="DynamicData" Version="9.2.1" />
         <PackageReference Include="MessageBox.Avalonia" Version="3.2.0" />
         <PackageReference Include="MessageBox.Avalonia.Markdown" Version="3.2.0" />


### PR DESCRIPTION
https://www.backblaze.com/docs/en/cloud-storage-use-the-aws-sdk-for-net-with-backblaze-b2?highlight=Data%20Integrity%20Protection%20Headers