### PR TITLE
Optimize the slicing of log messages from converter backends

### DIFF
--- a/Fronter.NET.Tests/Services/MessageSlicerTests.cs
+++ b/Fronter.NET.Tests/Services/MessageSlicerTests.cs
@@ -10,7 +10,7 @@ public class MessageSlicerTests {
 		const string message = "2000-06-06 15:23:33 [ALERT] test message";
 		var logLine = MessageSlicer.SliceMessage(message);
 
-		Assert.Equal("2000-06-06 15:23:33", logLine.Timestamp);
+		Assert.Equal("2000-06-06 15:23:33", actual: logLine.Timestamp.ToString("yyyy-MM-dd HH:mm:ss"));
 		Assert.Equal(Level.Alert, logLine.Level);
 		Assert.Equal("test message", logLine.Message);
 	}

--- a/Fronter.NET/App.axaml.cs
+++ b/Fronter.NET/App.axaml.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace Fronter;
 
-public sealed class App : Application {
+internal sealed class App : Application {
 	private static readonly ILog logger = LogManager.GetLogger("Frontend");
 	private const string FronterThemePath = "Configuration/fronter-theme.txt";
 	private const string DefaultTheme = "Dark";

--- a/Fronter.NET/Extensions/DynamicLocExtension.cs
+++ b/Fronter.NET/Extensions/DynamicLocExtension.cs
@@ -3,7 +3,7 @@ using Fronter.ValueConverters;
 
 namespace Fronter.Extensions;
 
-public sealed class DynamicLocExtension : MultiBinding {
+internal sealed class DynamicLocExtension : MultiBinding {
 	public DynamicLocExtension(string path) {
 		Bindings.Add(new Binding(path));
 

--- a/Fronter.NET/Extensions/LocExtension.cs
+++ b/Fronter.NET/Extensions/LocExtension.cs
@@ -3,7 +3,7 @@
 namespace Fronter.Extensions;
 
 // based on https://gist.github.com/jakubfijalkowski/0771bfbd26ce68456d3e
-public sealed class LocExtension : Binding {
+internal sealed class LocExtension : Binding {
 	public LocExtension(string locKey): base($"[{locKey}]", BindingMode.OneWay) {
 		Source = TranslationSource.Instance;
 	}

--- a/Fronter.NET/Extensions/LogExtensions.cs
+++ b/Fronter.NET/Extensions/LogExtensions.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Fronter.Extensions;
 
-public static class LogExtensions {
+internal static class LogExtensions {
 	public static void LogWithCustomTimestamp(this ILog log, DateTime timestamp, Level level, string message) {
 		var loggingEventDate = new LoggingEventData {
 			// The incoming timeStamp is in local timezone, but Log4Net expects it to be in UTC.

--- a/Fronter.NET/Fronter.csproj
+++ b/Fronter.NET/Fronter.csproj
@@ -97,6 +97,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Fronter.Tests"/>
+        <InternalsVisibleTo Include="Fronter.Tests" />
     </ItemGroup>
 </Project>

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -10,12 +10,11 @@ using log4net.Appender;
 using log4net.Core;
 using System;
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.Linq;
 
 namespace Fronter.LogAppenders;
 
-public sealed class LogGridAppender : MemoryAppender {
+internal sealed class LogGridAppender : MemoryAppender {
 	public ObservableCollection<LogLine> LogLines { get; } = [];
 	private ReadOnlyObservableCollection<LogLine> filteredLogLines;
 	public ReadOnlyObservableCollection<LogLine> FilteredLogLines => filteredLogLines;
@@ -33,20 +32,14 @@ public sealed class LogGridAppender : MemoryAppender {
 	}
 
 	protected override void Append(LoggingEvent loggingEvent) {
-		var newLogLine = new LogLine {
-			Level = loggingEvent.Level,
-			// Tab characters are incorrectly displayed in the log grid as of Avalonia 0.10.18.
-			Message = loggingEvent.RenderedMessage?.Replace("\t", "    ") ?? string.Empty,
-			Timestamp = GetTimestampString(loggingEvent.TimeStamp),
-		};
+		// Tab characters are incorrectly displayed in the log grid as of Avalonia 0.10.18.
+		string message = loggingEvent.RenderedMessage?.Replace("\t", "    ") ?? string.Empty;
+
+		var newLogLine = new LogLine(loggingEvent.TimeStamp, loggingEvent.Level, message);
 		AddToLogGrid(newLogLine);
 		ScrollToLogEnd();
 
 		base.Append(loggingEvent);
-	}
-
-	private static string GetTimestampString(DateTime dateTime) {
-		return dateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 	}
 
 	private void AddToLogGrid(LogLine logLine) {

--- a/Fronter.NET/LoggingConfigurator.cs
+++ b/Fronter.NET/LoggingConfigurator.cs
@@ -7,7 +7,7 @@ using Logger = commonItems.Logger;
 
 namespace Fronter;
 
-public static class LoggingConfigurator {
+internal static class LoggingConfigurator {
 	public static void ConfigureLogging(bool useConsole = false) {
 		var appenders = new List<IAppender>();
 

--- a/Fronter.NET/Models/Configuration/Mod.cs
+++ b/Fronter.NET/Models/Configuration/Mod.cs
@@ -3,7 +3,7 @@ using Fronter.ViewModels;
 
 namespace Fronter.Models.Configuration;
 
-public sealed class Mod : ViewModelBase {
+internal sealed class Mod : ViewModelBase {
 	public Mod(string modPath) {
 		var parser = new Parser();
 		parser.RegisterKeyword("name", reader => Name = reader.GetString());

--- a/Fronter.NET/Models/Configuration/Options/DateSelector.cs
+++ b/Fronter.NET/Models/Configuration/Options/DateSelector.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Fronter.Models.Configuration.Options;
 
-public sealed class DateSelector : ReactiveObject {
+internal sealed class DateSelector : ReactiveObject {
 	public DateSelector(BufferedReader reader) {
 		var parser = new Parser();
 		RegisterKeys(parser);

--- a/Fronter.NET/Models/Configuration/Options/TextSelector.cs
+++ b/Fronter.NET/Models/Configuration/Options/TextSelector.cs
@@ -2,7 +2,7 @@
 
 namespace Fronter.Models.Configuration.Options;
 
-public sealed class TextSelector {
+internal sealed class TextSelector {
 	public TextSelector(BufferedReader reader) {
 		var parser = new Parser();
 		RegisterKeys(parser);

--- a/Fronter.NET/Models/Configuration/Options/ToggleableOption.cs
+++ b/Fronter.NET/Models/Configuration/Options/ToggleableOption.cs
@@ -3,7 +3,7 @@ using ReactiveUI;
 
 namespace Fronter.Models.Configuration.Options;
 
-public sealed class ToggleableOption : ReactiveObject {
+internal sealed class ToggleableOption : ReactiveObject {
 	public ToggleableOption(BufferedReader reader, int id) {
 		Id = id;
 

--- a/Fronter.NET/Models/Configuration/RequiredFile.cs
+++ b/Fronter.NET/Models/Configuration/RequiredFile.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Fronter.Models.Configuration;
 
-public sealed class RequiredFile : RequiredPath {
+internal sealed class RequiredFile : RequiredPath {
 	private static readonly ILog logger = LogManager.GetLogger("Required file");
 	public RequiredFile(BufferedReader reader) {
 		var parser = new Parser();

--- a/Fronter.NET/Models/Configuration/RequiredPath.cs
+++ b/Fronter.NET/Models/Configuration/RequiredPath.cs
@@ -3,7 +3,7 @@ using ReactiveUI;
 
 namespace Fronter.Models.Configuration;
 
-public class RequiredPath : ViewModelBase {
+internal class RequiredPath : ViewModelBase {
 	public bool Mandatory { get; protected set; } = false;
 	public virtual bool Outputtable { get; protected set; } = false;
 	public string Name { get; protected set; } = string.Empty;

--- a/Fronter.NET/Models/ConverterReleaseAsset.cs
+++ b/Fronter.NET/Models/ConverterReleaseAsset.cs
@@ -2,7 +2,7 @@
 
 namespace Fronter.Models;
 
-public sealed class ConverterReleaseAsset {
+internal sealed class ConverterReleaseAsset {
 	[JsonPropertyName("name")] public string? Name { get; set; }
 	[JsonPropertyName("browser_download_url")] public string? BrowserDownloadUrl { get; set; }
 }

--- a/Fronter.NET/Models/FrontendTheme.cs
+++ b/Fronter.NET/Models/FrontendTheme.cs
@@ -2,7 +2,7 @@
 
 namespace Fronter.Models;
 
-public sealed class FrontendTheme : IIdentifiable<string> {
+internal sealed class FrontendTheme : IIdentifiable<string> {
 	public required string Id { get; init; }
 	public required string LocKey { get; init; }
 }

--- a/Fronter.NET/Models/LogLine.cs
+++ b/Fronter.NET/Models/LogLine.cs
@@ -1,14 +1,11 @@
 ﻿using log4net.Core;
 using ReactiveUI;
 using System;
-using System.Globalization;
 
 namespace Fronter.Models;
 
-public sealed class LogLine : ReactiveObject {
-	public string Timestamp { get; set; } = string.Empty;
-	public DateTime TimestampAsDateTime =>
-		string.IsNullOrWhiteSpace(Timestamp) ? DateTime.Now : Convert.ToDateTime(Timestamp, CultureInfo.InvariantCulture);
+internal sealed class LogLine : ReactiveObject {
+	public DateTime Timestamp { get; set; }
 	public Level? Level { get; set; }
 	public string LevelName => Level?.Name ?? string.Empty;
 
@@ -16,4 +13,10 @@ public sealed class LogLine : ReactiveObject {
 		get;
 		set => this.RaiseAndSetIfChanged(ref field, value);
 	} = string.Empty;
+
+	internal LogLine(DateTime timestamp, Level? level, string message) {
+		Timestamp = timestamp;
+		Level = level;
+		Message = message;
+	}
 }

--- a/Fronter.NET/Models/UpdateInfoModel.cs
+++ b/Fronter.NET/Models/UpdateInfoModel.cs
@@ -2,7 +2,7 @@
 
 namespace Fronter.Models;
 
-public sealed class UpdateInfoModel {
+internal sealed class UpdateInfoModel {
 	public string? Version { get; set; }
 	public string? Description { get; set; }
 	public string? AssetUrl { get; set; }

--- a/Fronter.NET/Services/BrowserLauncher.cs
+++ b/Fronter.NET/Services/BrowserLauncher.cs
@@ -2,7 +2,7 @@
 
 namespace Fronter.Services;
 
-public static class BrowserLauncher {
+internal static class BrowserLauncher {
 	public static void Open(string url) {
 		Process.Start(new ProcessStartInfo {
 			FileName = url,

--- a/Fronter.NET/Services/ConverterLauncher.cs
+++ b/Fronter.NET/Services/ConverterLauncher.cs
@@ -82,13 +82,10 @@ internal sealed class ConverterLauncher {
 				return;
 			}
 
-			// Get timestamp datetime.
-			DateTime timestamp = logLine.TimestampAsDateTime;
-
 			// Get level to display.
 			var logLevel = level ?? lastLevelFromBackend ?? Level.Info;
 
-			logger.LogWithCustomTimestamp(timestamp, logLevel, logLine.Message);
+			logger.LogWithCustomTimestamp(logLine.Timestamp, logLevel, logLine.Message);
 
 			if (level is not null) {
 				lastLevelFromBackend = level;

--- a/Fronter.NET/Services/ElevatedPrivilegesDetector.cs
+++ b/Fronter.NET/Services/ElevatedPrivilegesDetector.cs
@@ -3,7 +3,7 @@ using System.Security.Principal;
 
 namespace Fronter.Services;
 
-public static class ElevatedPrivilegesDetector {
+internal static class ElevatedPrivilegesDetector {
 	public static bool IsAdministrator =>
 		OperatingSystem.IsWindows() ?
 			new WindowsPrincipal(WindowsIdentity.GetCurrent())

--- a/Fronter.NET/Services/MessageSlicer.cs
+++ b/Fronter.NET/Services/MessageSlicer.cs
@@ -1,45 +1,156 @@
-﻿using Fronter.Models;
+﻿using commonItems;
+using Fronter.Models;
 using log4net;
 using log4net.Core;
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace Fronter.Services;
 
-public static partial class MessageSlicer {
-	private static readonly ILog logger = LogManager.GetLogger("Frontend");
-	private static readonly Regex dateTimeRegex = GetDateTimeRegex();
+internal static partial class MessageSlicer {
+    private static readonly ILog logger = LogManager.GetLogger("Frontend");
 
-	public static LogLine SliceMessage(string message) {
-		var logMessage = new LogLine();
+    public static LogLine SliceMessageV2(string message) {
+        ReadOnlySpan<char> span = message.AsSpan();
 
+        int posOpen = span.IndexOf('[');
+        int posClose = span.IndexOf(']');
+
+        if (posOpen < 0 || posOpen > posClose) {
+			return new LogLine(DateTime.Now, level: null, message);
+		}
+
+        ReadOnlySpan<char> timestampSpan = span[..posOpen].Trim();
+		DateTime timestamp;
+		if (IsTimestamp(timestampSpan)) {
+			timestamp = DateTime.ParseExact(timestampSpan, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+		} else {
+			timestamp = DateTime.Now;
+			var trimmedStart = span.TrimStart();
+			if (trimmedStart.IsEmpty || trimmedStart[0] != '[') {
+				return new LogLine(timestamp, level: null, message);
+			}
+		}
+
+		var levelSpan = span.Slice(posOpen + 1, posClose - posOpen - 1);
+		Level? level = GetLogLevel(levelSpan);
+
+		string msg = string.Empty;
+		if (message.Length >= posClose + 2) {
+			msg = message[(posClose + 2)..];
+		}
+
+        return new LogLine(timestamp, level, msg);
+	}
+
+    private static Level GetLogLevel(ReadOnlySpan<char> levelSpan) {
+		// Map common levels without allocations.
+		// For optimal performance, order by expected frequency.
+		if (levelSpan.Equals("DEBUG".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Debug;
+		}
+		if (levelSpan.Equals("INFO".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Info;
+		}
+		if (levelSpan.Equals("PROGRESS".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return LogExtensions.ProgressLevel;
+		}
+		if (levelSpan.Equals("WARN".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Warn;
+		}
+		if (levelSpan.Equals("NOTICE".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Notice;
+		}
+		if (levelSpan.Equals("ERROR".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Error;
+		}
+		if (levelSpan.Equals("FATAL".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Fatal;
+		}
+		if (levelSpan.Equals("WARNING".AsSpan(), StringComparison.OrdinalIgnoreCase)) {
+			return Level.Warn;
+		}
+
+		string levelKey = new(levelSpan);
+		var level = LogManager.GetRepository().LevelMap[levelKey];
+        if (level == null) {
+            logger.Warn($"Unknown log level: {levelKey}");
+            level = Level.Debug;
+        }
+
+        return level;
+    }
+
+    private static bool IsTimestamp(ReadOnlySpan<char> s) {
+        // Fast check for format: yyyy-MM-dd HH:mm:ss (length 19)
+        if (s.Length != 19) return false;
+
+        static bool IsDigit(char c) => (uint)(c - '0') <= 9u;
+
+        // yyyy
+        if (!IsDigit(s[0]) || !IsDigit(s[1]) || !IsDigit(s[2]) || !IsDigit(s[3])) return false;
+        // -
+        if (s[4] != '-') return false;
+        // MM
+        if (!IsDigit(s[5]) || !IsDigit(s[6])) return false;
+        // -
+        if (s[7] != '-') return false;
+        // dd
+        if (!IsDigit(s[8]) || !IsDigit(s[9])) return false;
+        // space
+        if (s[10] != ' ') return false;
+        // HH
+        if (!IsDigit(s[11]) || !IsDigit(s[12])) return false;
+        // :
+        if (s[13] != ':') return false;
+        // mm
+        if (!IsDigit(s[14]) || !IsDigit(s[15])) return false;
+        // :
+        if (s[16] != ':') return false;
+        // ss
+        if (!IsDigit(s[17]) || !IsDigit(s[18])) return false;
+
+        return true;
+    }
+
+
+	public static LogLine SliceMessage(string message) => SliceMessageV2(message);
+
+	public static LogLine SliceMessageV1(string message) {
 		var posOpen = message.IndexOf('[');
 		var posClose = message.IndexOf(']');
 
 		if (posOpen < 0 || posOpen > posClose) {
-			logMessage.Message = message;
-			return logMessage;
+			return new LogLine(DateTime.Now, level: null, message);
 		}
 
 		var timestampPart = message[..posOpen].Trim();
+		string msg = string.Empty;
+		Level? level;
+		DateTime timestamp;
 		if (dateTimeRegex.IsMatch(timestampPart)) {
-			logMessage.Timestamp = timestampPart;
-		} else if (!message.TrimStart().StartsWith('[')){
-			logMessage.Message = message;
-			logMessage.Level = null;
-			return logMessage;
+			timestamp = Convert.ToDateTime(timestampPart);
+		} else if (!message.TrimStart().StartsWith('[')) {
+			timestamp = DateTime.Now;
+			msg = message;
+			level = null;
+			return new LogLine(timestamp, level, msg);
 		}
 
+		timestamp = DateTime.Now;
 		var logLevelStr = message.Substring(posOpen + 1, posClose - posOpen - 1);
-		logMessage.Level = GetLogLevel(logLevelStr);
+		level = GetLogLevelV1(logLevelStr);
 		if (message.Length >= posClose + 2) {
-			logMessage.Message = message[(posClose + 2)..];
+			msg = message[(posClose + 2)..];
 		}
 
-		return logMessage;
+		return new LogLine(timestamp, level, msg);
 	}
 
-	private static Level GetLogLevel(string levelStr) {
+
+
+	private static Level GetLogLevelV1(string levelStr) { // TODO: remove this after switching to V2
 		if (levelStr.Equals("WARNING", StringComparison.OrdinalIgnoreCase)) {
 			levelStr = "WARN";
 		}
@@ -52,6 +163,7 @@ public static partial class MessageSlicer {
 		return level;
 	}
 
+	private static readonly Regex dateTimeRegex = GetDateTimeRegex(); // TODO: remove this after switching to V2
 	[GeneratedRegex(@"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})$")]
-	private static partial Regex GetDateTimeRegex();
+	private static partial Regex GetDateTimeRegex(); // TODO: remove this after switching to V2
 }

--- a/Fronter.NET/ValueConverters/EnumToBooleanConverter.cs
+++ b/Fronter.NET/ValueConverters/EnumToBooleanConverter.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace Fronter.ValueConverters;
 
-public sealed class EnumToBooleanConverter : IValueConverter {
+internal sealed class EnumToBooleanConverter : IValueConverter {
 	public static readonly EnumToBooleanConverter Instance = new();
 
 	public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) {

--- a/Fronter.NET/ValueConverters/LocKeyToValueConverter.cs
+++ b/Fronter.NET/ValueConverters/LocKeyToValueConverter.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 
 namespace Fronter.ValueConverters;
 
-public sealed class LocKeyToValueConverter : IMultiValueConverter {
+internal sealed class LocKeyToValueConverter : IMultiValueConverter {
 	public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture) {
 		return values[0] is string locKey ? TranslationSource.Instance[locKey] : AvaloniaProperty.UnsetValue;
 	}

--- a/Fronter.NET/ValueConverters/LogLevelToColorNameConverter.cs
+++ b/Fronter.NET/ValueConverters/LogLevelToColorNameConverter.cs
@@ -6,20 +6,23 @@ using System;
 namespace Fronter.ValueConverters;
 
 // based on https://stackoverflow.com/a/5551986/10249243
-public sealed class LogLevelToColorNameConverter : IValueConverter {
+internal sealed class LogLevelToColorNameConverter : IValueConverter {
 	public object Convert(object? value, Type targetType, object? parameter, System.Globalization.CultureInfo culture) {
-		var input = value as Level;
-		return input?.Name switch {
-			"PROGRESS" => Brushes.ForestGreen,
-			"NOTICE" => Brushes.CornflowerBlue,
-			"FATAL" => Brushes.DarkRed,
-			"CRITICAL" => Brushes.Red,
-			"ERROR" => Brushes.IndianRed,
-			"WARN" => Brushes.Orange,
-			"WARNING" => Brushes.Orange,
-			"INFO" => Brushes.Transparent,
+		if (value is not Level input) {
+			return Brushes.Transparent;
+		}
+		// Tried to order this by expected frequency for better performance.
+		return input.Name switch {
 			"DEBUG" => Brushes.SlateGray,
-			_ => Brushes.Transparent
+			"INFO" => Brushes.Transparent,
+			"PROGRESS" => Brushes.ForestGreen,
+			"WARN" => Brushes.Orange,
+			"NOTICE" => Brushes.CornflowerBlue,
+			"ERROR" => Brushes.IndianRed,
+			"FATAL" => Brushes.DarkRed,
+			"WARNING" => Brushes.Orange,
+			"CRITICAL" => Brushes.Red,
+			_ => Brushes.Transparent,
 		};
 	}
 

--- a/Fronter.NET/ViewLocator.cs
+++ b/Fronter.NET/ViewLocator.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Fronter;
 
-public sealed class ViewLocator : IDataTemplate {
+internal sealed class ViewLocator : IDataTemplate {
 	public Control Build(object? data) {
 		if (data is null) {
 			return new TextBlock { Text = "Not Found." };

--- a/Fronter.NET/ViewModels/MenuItemViewModel.cs
+++ b/Fronter.NET/ViewModels/MenuItemViewModel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Fronter.ViewModels;
 
-public sealed class MenuItemViewModel {
+internal sealed class MenuItemViewModel {
 	public required string Header { get; set; }
 	public required IReactiveCommand Command { get; set; }
 	public required object CommandParameter { get; set; }

--- a/Fronter.NET/ViewModels/ViewModelBase.cs
+++ b/Fronter.NET/ViewModels/ViewModelBase.cs
@@ -2,4 +2,4 @@
 
 namespace Fronter.ViewModels;
 
-public class ViewModelBase : ReactiveObject;
+internal class ViewModelBase : ReactiveObject;

--- a/Fronter.NET/Views/MainWindow.axaml.cs
+++ b/Fronter.NET/Views/MainWindow.axaml.cs
@@ -4,7 +4,7 @@ using Avalonia.Markup.Xaml;
 
 namespace Fronter.Views;
 
-public sealed partial class MainWindow : Window {
+internal sealed partial class MainWindow : Window {
 	public static MainWindow Instance { get; } = new();
 
 	public MainWindow() {

--- a/Fronter.NET/Views/ModsPickerView.axaml.cs
+++ b/Fronter.NET/Views/ModsPickerView.axaml.cs
@@ -3,7 +3,7 @@ using Avalonia.Markup.Xaml;
 
 namespace Fronter.Views;
 
-public sealed partial class ModsPickerView : UserControl {
+internal sealed partial class ModsPickerView : UserControl {
 	public ModsPickerView() {
 		InitializeComponent();
 	}

--- a/Fronter.NET/Views/OptionsView.axaml.cs
+++ b/Fronter.NET/Views/OptionsView.axaml.cs
@@ -3,7 +3,7 @@ using Avalonia.Markup.Xaml;
 
 namespace Fronter.Views;
 
-public sealed partial class OptionsView : UserControl {
+internal sealed partial class OptionsView : UserControl {
 	public OptionsView() {
 		InitializeComponent();
 	}

--- a/Fronter.NET/Views/PathPickerView.axaml.cs
+++ b/Fronter.NET/Views/PathPickerView.axaml.cs
@@ -3,7 +3,7 @@ using Avalonia.Markup.Xaml;
 
 namespace Fronter.Views;
 
-public sealed partial class PathPickerView : UserControl {
+internal sealed partial class PathPickerView : UserControl {
 	public PathPickerView() {
 		InitializeComponent();
 	}

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "9.0.200",
     "allowPrerelease": true,
-    "rollForward": "latestPatch"
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Benchmarked for BenchmarkDotNet. This change should result in better speed and reduced heap memory allocation.