### PR TITLE
Optimize the log grid

### DIFF
--- a/Fronter.NET.Tests/LogAppenders/LogGridAppenderTests.cs
+++ b/Fronter.NET.Tests/LogAppenders/LogGridAppenderTests.cs
@@ -2,6 +2,7 @@ using commonItems;
 using Fronter.LogAppenders;
 using Fronter.Models;
 using log4net.Core;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Fronter.Tests.LogAppenders;
@@ -42,5 +43,17 @@ public class LogGridAppenderTests {
 		var success = LogGridAppender.TryGetProgressValue(logLine, out _);
 
 		Assert.False(success);
+	}
+
+	[Fact]
+	public async Task ClearDisplayedLogLines_ClearsRows_WhenAwaited() {
+		var appender = new LogGridAppender();
+		appender.LogLines.Add(new LogLine(System.DateTime.Now, Level.Warn, "warning"));
+		appender.LogLines.Add(new LogLine(System.DateTime.Now, Level.Error, "error"));
+
+		await appender.ClearDisplayedLogLines();
+
+		Assert.Empty(appender.LogLines);
+		Assert.Empty(appender.FilteredLogLines);
 	}
 }

--- a/Fronter.NET.Tests/LogAppenders/LogGridAppenderTests.cs
+++ b/Fronter.NET.Tests/LogAppenders/LogGridAppenderTests.cs
@@ -1,0 +1,24 @@
+using Fronter.LogAppenders;
+using Fronter.Models;
+using log4net.Core;
+using Xunit;
+
+namespace Fronter.Tests.LogAppenders;
+
+[Collection("Sequential")]
+public class LogGridAppenderTests {
+	[Fact]
+	public void ToggleLogFilterLevel_DoesNotSurfaceStandaloneContinuationRows() {
+		var appender = new LogGridAppender();
+
+		appender.LogLines.Add(new LogLine(System.DateTime.Now, Level.Warn, "visible warning"));
+		appender.LogLines.Add(new LogLine(System.DateTime.Now, null, "continuation"));
+
+		Assert.Single(appender.FilteredLogLines);
+
+		appender.LogFilterLevel = Level.Info;
+		appender.ToggleLogFilterLevel();
+
+		Assert.Single(appender.FilteredLogLines);
+	}
+}

--- a/Fronter.NET.Tests/LogAppenders/LogGridAppenderTests.cs
+++ b/Fronter.NET.Tests/LogAppenders/LogGridAppenderTests.cs
@@ -1,3 +1,4 @@
+using commonItems;
 using Fronter.LogAppenders;
 using Fronter.Models;
 using log4net.Core;
@@ -20,5 +21,26 @@ public class LogGridAppenderTests {
 		appender.ToggleLogFilterLevel();
 
 		Assert.Single(appender.FilteredLogLines);
+	}
+
+	[Theory]
+	[InlineData("42%", (ushort)42)]
+	[InlineData(" 7 ", (ushort)7)]
+	public void TryGetProgressValue_ReturnsParsedProgressForProgressRows(string message, ushort expectedValue) {
+		var logLine = new LogLine(System.DateTime.Now, LogExtensions.ProgressLevel, message);
+
+		var success = LogGridAppender.TryGetProgressValue(logLine, out var progressValue);
+
+		Assert.True(success);
+		Assert.Equal(expectedValue, progressValue);
+	}
+
+	[Fact]
+	public void TryGetProgressValue_ReturnsFalseForNonProgressRows() {
+		var logLine = new LogLine(System.DateTime.Now, Level.Info, "42%");
+
+		var success = LogGridAppender.TryGetProgressValue(logLine, out _);
+
+		Assert.False(success);
 	}
 }

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -9,12 +9,21 @@ using Fronter.ViewModels;
 using log4net.Appender;
 using log4net.Core;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading;
 
 namespace Fronter.LogAppenders;
 
-internal sealed class LogGridAppender : MemoryAppender {
+internal sealed class LogGridAppender : AppenderSkeleton {
+	private readonly ConcurrentQueue<LogLine> pendingLogLines = new();
+	private IDisposable? logFilterSubscription;
+	private int flushScheduled;
+	private ushort? latestProgressValue;
+	private LogLine? lastLogRow;
+	private LogLine? lastVisibleRow;
+
 	public ObservableCollection<LogLine> LogLines { get; } = [];
 	private ReadOnlyObservableCollection<LogLine> filteredLogLines;
 	public ReadOnlyObservableCollection<LogLine> FilteredLogLines => filteredLogLines;
@@ -24,71 +33,123 @@ internal sealed class LogGridAppender : MemoryAppender {
 	public DataGrid? LogGrid { get; set; }
 
 	public LogGridAppender() {
-		// The idea of notice in the converters was to display the notice regardless of filtering level.
-		LogLines.ToObservableChangeSet()
-			.Filter(line => line.Level == Level.Notice || line.Level >= LogFilterLevel)
-			.Bind(out filteredLogLines)
-			.Subscribe();
+		filteredLogLines = new ReadOnlyObservableCollection<LogLine>([]);
+		RebuildFilterBinding();
 	}
+
+	protected override bool RequiresLayout => false;
 
 	protected override void Append(LoggingEvent loggingEvent) {
 		// Tab characters are incorrectly displayed in the log grid as of Avalonia 0.10.18.
 		string message = loggingEvent.RenderedMessage?.Replace("\t", "    ") ?? string.Empty;
-
 		var newLogLine = new LogLine(loggingEvent.TimeStamp, loggingEvent.Level, message);
-		AddToLogGrid(newLogLine);
-		ScrollToLogEnd();
+		pendingLogLines.Enqueue(newLogLine);
 
-		base.Append(loggingEvent);
+		if (loggingEvent.Level == LogExtensions.ProgressLevel &&
+		    ushort.TryParse(message.Trim().TrimEnd('%'), out var progressValue)) {
+			latestProgressValue = progressValue;
+		}
+
+		ScheduleFlush();
 	}
 
-	private void AddToLogGrid(LogLine logLine) {
-		if (logLine.Level is null) {
-			Dispatcher.UIThread.Post(
-				() => AppendToLastLogRow(logLine),
-				DispatcherPriority.Normal
-			);
-		} else {
-			AddRowToLogGrid(logLine);
-			if (logLine.Level == LogExtensions.ProgressLevel) {
-				if (ushort.TryParse(logLine.Message.Trim().TrimEnd('%'), out var progressValue)) {
-					Dispatcher.UIThread.Post(() => {
-						if (Avalonia.Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) {
-							return;
-						}
+	public void ToggleLogFilterLevel() {
+		RebuildFilterBinding();
+		lastVisibleRow = filteredLogLines.LastOrDefault();
+	}
 
-						if (desktop.MainWindow?.DataContext is MainWindowViewModel mainWindowDataContext) {
-							mainWindowDataContext.Progress = progressValue;
-						}
-					});
+	public void ClearDisplayedLogLines() {
+		while (pendingLogLines.TryDequeue(out _)) {
+		}
+
+		latestProgressValue = null;
+		Dispatcher.UIThread.Post(() => {
+			LogLines.Clear();
+			lastLogRow = null;
+			lastVisibleRow = null;
+		}, DispatcherPriority.Normal);
+	}
+
+	protected override void OnClose() {
+		logFilterSubscription?.Dispose();
+		base.OnClose();
+	}
+
+	private void RebuildFilterBinding() {
+		logFilterSubscription?.Dispose();
+		logFilterSubscription = LogLines.ToObservableChangeSet()
+			.Filter(IsVisibleForCurrentFilter)
+			.Bind(out filteredLogLines)
+			.Subscribe();
+	}
+
+	private bool IsVisibleForCurrentFilter(LogLine line) {
+		return line.Level == Level.Notice || line.Level is not null && line.Level >= LogFilterLevel;
+	}
+
+	private void ScheduleFlush() {
+		if (Interlocked.Exchange(ref flushScheduled, 1) == 1) {
+			return;
+		}
+
+		Dispatcher.UIThread.Post(FlushPendingLogLines, DispatcherPriority.Background);
+	}
+
+	private void FlushPendingLogLines() {
+		try {
+			bool shouldScroll = false;
+			while (pendingLogLines.TryDequeue(out var logLine)) {
+				if (logLine.Level is null) {
+					AppendToLastLogRow(logLine);
+					continue;
 				}
+
+				LogLines.Add(logLine);
+				lastLogRow = logLine;
+				if (IsVisibleForCurrentFilter(logLine)) {
+					lastVisibleRow = logLine;
+					shouldScroll = true;
+				}
+			}
+
+			UpdateProgressIfNeeded();
+
+			if (shouldScroll) {
+				ScrollToLogEnd();
+			}
+		} finally {
+			Interlocked.Exchange(ref flushScheduled, 0);
+			if (!pendingLogLines.IsEmpty) {
+				ScheduleFlush();
 			}
 		}
 	}
 
-	public void ToggleLogFilterLevel() {
-		LogLines.ToObservableChangeSet()
-			.Filter(line => line.Level is null || line.Level == Level.Notice || line.Level >= LogFilterLevel)
-			.Bind(out filteredLogLines)
-			.Subscribe();
-		lastVisibleRow = filteredLogLines.LastOrDefault();
-	}
+	private void UpdateProgressIfNeeded() {
+		if (latestProgressValue is not ushort progressValue) {
+			return;
+		}
 
-	private LogLine? lastLogRow;
-	private LogLine? lastVisibleRow;
-	private void AddRowToLogGrid(LogLine logLine) {
-		Dispatcher.UIThread.Post(() => LogLines.Add(logLine));
-		lastLogRow = logLine;
-		if (logLine.Level is not null && logLine.Level >= LogFilterLevel) {
-			lastVisibleRow = logLine;
+		latestProgressValue = null;
+		if (Avalonia.Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) {
+			return;
+		}
+
+		if (desktop.MainWindow?.DataContext is MainWindowViewModel mainWindowDataContext) {
+			mainWindowDataContext.Progress = progressValue;
 		}
 	}
 
 	private void AppendToLastLogRow(LogLine logLine) {
 		if (lastLogRow is null) {
-			AddRowToLogGrid(logLine);
-		} else {
-			lastLogRow.Message += $"\n{logLine.Message}";
+			LogLines.Add(logLine);
+			lastLogRow = logLine;
+			return;
+		}
+
+		lastLogRow.Message += $"\n{logLine.Message}";
+		if (IsVisibleForCurrentFilter(lastLogRow)) {
+			lastVisibleRow = lastLogRow;
 		}
 	}
 

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -20,7 +20,6 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 	private readonly ConcurrentQueue<LogLine> pendingLogLines = new();
 	private IDisposable? logFilterSubscription;
 	private int flushScheduled;
-	private ushort? latestProgressValue;
 	private LogLine? lastLogRow;
 	private LogLine? lastVisibleRow;
 
@@ -44,12 +43,6 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 		string message = loggingEvent.RenderedMessage?.Replace("\t", "    ") ?? string.Empty;
 		var newLogLine = new LogLine(loggingEvent.TimeStamp, loggingEvent.Level, message);
 		pendingLogLines.Enqueue(newLogLine);
-
-		if (loggingEvent.Level == LogExtensions.ProgressLevel &&
-		    ushort.TryParse(message.Trim().TrimEnd('%'), out var progressValue)) {
-			latestProgressValue = progressValue;
-		}
-
 		ScheduleFlush();
 	}
 
@@ -62,7 +55,6 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 		while (pendingLogLines.TryDequeue(out _)) {
 		}
 
-		latestProgressValue = null;
 		Dispatcher.UIThread.Post(() => {
 			LogLines.Clear();
 			lastLogRow = null;
@@ -98,6 +90,7 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 	private void FlushPendingLogLines() {
 		try {
 			bool shouldScroll = false;
+			ushort? latestProgressValueInBatch = null;
 			while (pendingLogLines.TryDequeue(out var logLine)) {
 				if (logLine.Level is null) {
 					AppendToLastLogRow(logLine);
@@ -106,13 +99,16 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 
 				LogLines.Add(logLine);
 				lastLogRow = logLine;
+				if (TryGetProgressValue(logLine, out var progressValue)) {
+					latestProgressValueInBatch = progressValue;
+				}
 				if (IsVisibleForCurrentFilter(logLine)) {
 					lastVisibleRow = logLine;
 					shouldScroll = true;
 				}
 			}
 
-			UpdateProgressIfNeeded();
+			UpdateProgressIfNeeded(latestProgressValueInBatch);
 
 			if (shouldScroll) {
 				ScrollToLogEnd();
@@ -125,12 +121,21 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 		}
 	}
 
-	private void UpdateProgressIfNeeded() {
-		if (latestProgressValue is not ushort progressValue) {
+	internal static bool TryGetProgressValue(LogLine logLine, out ushort progressValue) {
+		if (logLine.Level == LogExtensions.ProgressLevel &&
+		    ushort.TryParse(logLine.Message.Trim().TrimEnd('%'), out progressValue)) {
+			return true;
+		}
+
+		progressValue = 0;
+		return false;
+	}
+
+	private void UpdateProgressIfNeeded(ushort? latestProgressValueInBatch) {
+		if (latestProgressValueInBatch is not ushort progressValue) {
 			return;
 		}
 
-		latestProgressValue = null;
 		if (Avalonia.Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop) {
 			return;
 		}

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -40,8 +40,7 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 	protected override bool RequiresLayout => false;
 
 	protected override void Append(LoggingEvent loggingEvent) {
-		// Tab characters are incorrectly displayed in the log grid as of Avalonia 0.10.18.
-		string message = loggingEvent.RenderedMessage?.Replace("\t", "    ") ?? string.Empty;
+		string message = loggingEvent.RenderedMessage ?? string.Empty;
 		var newLogLine = new LogLine(loggingEvent.TimeStamp, loggingEvent.Level, message);
 		pendingLogLines.Enqueue(newLogLine);
 		ScheduleFlush();

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -13,6 +13,7 @@ using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Fronter.LogAppenders;
 
@@ -51,15 +52,22 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 		lastVisibleRow = filteredLogLines.LastOrDefault();
 	}
 
-	public void ClearDisplayedLogLines() {
-		while (pendingLogLines.TryDequeue(out _)) {
-		}
+	public async Task ClearDisplayedLogLines() {
+		void ClearCore() {
+			while (pendingLogLines.TryDequeue(out _)) {
+			}
 
-		Dispatcher.UIThread.Post(() => {
 			LogLines.Clear();
 			lastLogRow = null;
 			lastVisibleRow = null;
-		}, DispatcherPriority.Normal);
+		}
+
+		if (Dispatcher.UIThread.CheckAccess()) {
+			ClearCore();
+			return;
+		}
+
+		await Dispatcher.UIThread.InvokeAsync(ClearCore, DispatcherPriority.Normal);
 	}
 
 	protected override void OnClose() {

--- a/Fronter.NET/LogAppenders/LogGridAppender.cs
+++ b/Fronter.NET/LogAppenders/LogGridAppender.cs
@@ -84,7 +84,7 @@ internal sealed class LogGridAppender : AppenderSkeleton {
 	}
 
 	private bool IsVisibleForCurrentFilter(LogLine line) {
-		return line.Level == Level.Notice || line.Level is not null && line.Level >= LogFilterLevel;
+		return line.Level == Level.Notice || (line.Level is not null && line.Level >= LogFilterLevel);
 	}
 
 	private void ScheduleFlush() {

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -166,8 +166,8 @@ internal sealed class MainWindowViewModel : ViewModelBase {
 		return true;
 	}
 
-	private void ClearLogGrid() {
-		LogGridAppender.ClearDisplayedLogLines();
+	private Task ClearLogGrid() {
+		return LogGridAppender.ClearDisplayedLogLines();
 	}
 
 	private void CopyToTargetGameModDirectory() {
@@ -188,7 +188,7 @@ internal sealed class MainWindowViewModel : ViewModelBase {
 	}
 	public async Task LaunchConverter() {
 		ConvertButtonEnabled = false;
-		ClearLogGrid();
+		await ClearLogGrid();
 
 		Progress = 0;
 		SaveStatus = "CONVERTSTATUSPRE";

--- a/Fronter.NET/ViewModels/MainWindowViewModel.cs
+++ b/Fronter.NET/ViewModels/MainWindowViewModel.cs
@@ -167,7 +167,7 @@ internal sealed class MainWindowViewModel : ViewModelBase {
 	}
 
 	private void ClearLogGrid() {
-		LogGridAppender.LogLines.Clear();
+		LogGridAppender.ClearDisplayedLogLines();
 	}
 
 	private void CopyToTargetGameModDirectory() {

--- a/Fronter.NET/Views/MainWindow.axaml
+++ b/Fronter.NET/Views/MainWindow.axaml
@@ -153,11 +153,13 @@
             <DataGrid Name="LogGrid" Grid.Column="0" Grid.Row="2"
                       ItemsSource="{Binding FilteredLogLines}"
                       AutoGenerateColumns="False"
+                      IsReadOnly="True"
                       CanUserReorderColumns="False"
+                      CanUserResizeColumns="False"
                       CanUserSortColumns="False"
                       RowBackground="Transparent"
                       VerticalScrollBarVisibility="Visible"
-                      GridLinesVisibility="All"
+                      GridLinesVisibility="Horizontal"
                       >
                 <DataGrid.Resources>
                     <vc:LogLevelToColorNameConverter x:Key="LogLevelToColorNameConverter"/>
@@ -168,9 +170,9 @@
                     </Style>
                 </DataGrid.Styles>
                 <DataGrid.Columns>
-                    <DataGridTextColumn Header="{ns:Loc LOGTIME}" IsReadOnly="True" Binding="{Binding Timestamp}" />
-                    <DataGridTextColumn Header="{ns:Loc LOGSEVERITY}" IsReadOnly="True" Binding="{Binding LevelName}" />
-                    <DataGridTextColumn Header="{ns:Loc LOGMESSAGE}" IsReadOnly="True" Binding="{Binding Message}" />
+                    <DataGridTextColumn Header="{ns:Loc LOGTIME}" Width="160" IsReadOnly="True" Binding="{Binding Timestamp}" />
+                    <DataGridTextColumn Header="{ns:Loc LOGSEVERITY}" Width="110" IsReadOnly="True" Binding="{Binding LevelName}" />
+                    <DataGridTextColumn Header="{ns:Loc LOGMESSAGE}" Width="*" IsReadOnly="True" Binding="{Binding Message}" />
                 </DataGrid.Columns>
             </DataGrid>
         </Grid>


### PR DESCRIPTION
One of the changes is that the auto-scroll churn has been reduced to once per flush cycle.